### PR TITLE
sorted the types of values of cpus to easily get decoded

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     deploy:
         resources:
             limits:
-              cpus: 0.50
+              cpus: '0.50'
               memory: 512M
             reservations:
               memory: 128M
@@ -85,7 +85,7 @@ services:
     deploy:
         resources:
             limits:
-              cpus: 0.50
+              cpus: '0.50'
               memory: 512M
             reservations:
               memory: 128M


### PR DESCRIPTION
The version of the docker-compose file doesn't allow decoding the cpus value as float but rather allows decoding it as string. This is a solution regarding the issue no 3 : https://github.com/r4ulcl/WiFiChallengeLab-docker/issues/3