### PR TITLE
vagrantfile: grub-pc & debconf-set-selections

### DIFF
--- a/vagrant/vagrantfile
+++ b/vagrant/vagrantfile
@@ -23,6 +23,10 @@ Vagrant.configure('2') do |config|
     hv_vm.vm.provision 'shell',
       inline: <<~SHELL,
         set -e
+        ROOT_SRC="$(findmnt -no SOURCE /)"
+        ROOT_DEV="/dev/$(lsblk -no PKNAME "$ROOT_SRC" 2>/dev/null | head -n1)"
+        [ -b "$ROOT_DEV" ] || ROOT_DEV=/dev/sda
+        echo "grub-pc grub-pc/install_devices multiselect $ROOT_DEV" | debconf-set-selections
         apt-get update -y
         DEBIAN_FRONTEND=noninteractive apt-get full-upgrade -y
       SHELL
@@ -86,6 +90,10 @@ Vagrant.configure('2') do |config|
       inline: <<~SHELL,
         set -e
         export DEBIAN_FRONTEND=noninteractive
+        ROOT_SRC="$(findmnt -no SOURCE /)"
+        ROOT_DEV="/dev/$(lsblk -no PKNAME "$ROOT_SRC" 2>/dev/null | head -n1)"
+        [ -b "$ROOT_DEV" ] || ROOT_DEV=/dev/sda
+        echo "grub-pc grub-pc/install_devices multiselect $ROOT_DEV" | debconf-set-selections
         apt-get update -y
         apt-get full-upgrade -y
       SHELL
@@ -183,6 +191,10 @@ Vagrant.configure('2') do |config|
     vmw_vm.vm.provision 'shell',
       inline: <<~SHELL,
         set -e
+        ROOT_SRC="$(findmnt -no SOURCE /)"
+        ROOT_DEV="/dev/$(lsblk -no PKNAME "$ROOT_SRC" 2>/dev/null | head -n1)"
+        [ -b "$ROOT_DEV" ] || ROOT_DEV=/dev/sda
+        echo "grub-pc grub-pc/install_devices multiselect $ROOT_DEV" | debconf-set-selections
         apt-get update -y
         DEBIAN_FRONTEND=noninteractive apt-get full-upgrade -y
       SHELL
@@ -238,6 +250,10 @@ Vagrant.configure('2') do |config|
       inline: <<~SHELL,
         set -e
         export DEBIAN_FRONTEND=noninteractive
+        ROOT_SRC="$(findmnt -no SOURCE /)"
+        ROOT_DEV="/dev/$(lsblk -no PKNAME "$ROOT_SRC" 2>/dev/null | head -n1)"
+        [ -b "$ROOT_DEV" ] || ROOT_DEV=/dev/vda
+        echo "grub-pc grub-pc/install_devices multiselect $ROOT_DEV" | debconf-set-selections
         apt-get update -y
         apt-get full-upgrade -y
       SHELL


### PR DESCRIPTION
## Issue:

>     virtualbox_vm: Setting up grub-pc (2.06-13+deb12u2) ...
>     virtualbox_vm: grub-pc: Running grub-install ...
>     virtualbox_vm: /dev/disk/by-id/ata-VBOX_HARDDISK_VBef3f4778-d7168a38 does not exist, so cannot grub-install to it!
>     virtualbox_vm: You must correct your GRUB install devices before proceeding:
>     virtualbox_vm:
>     virtualbox_vm:   DEBIAN_FRONTEND=dialog dpkg --configure grub-pc
>     virtualbox_vm:   dpkg --configure -a
>     virtualbox_vm: dpkg: error processing package grub-pc (--configure):
>     virtualbox_vm:  installed grub-pc package post-installation script subprocess returned error exit status 1
> [...]
>     virtualbox_vm: Errors were encountered while processing:
>     virtualbox_vm:  grub-pc
>     virtualbox_vm: E: Sub-process /usr/bin/dpkg returned an error code (1)
> The SSH command responded with a non-zero exit status. Vagrant
> assumes that this means the command failed. The output for this command
> should be in the log above. Please read the output to determine what
> went wrong.

## Log

```console
┌──(root㉿kali)-[~/.wifichallengelab-docker/vagrant]
└─# vagrant plugin install vagrant-reload
Installing the 'vagrant-reload' plugin. This can take a few minutes...
Fetching vagrant-reload-0.0.1.gem
Installed the plugin 'vagrant-reload (0.0.1)'!

┌──(root㉿kali)-[~/.wifichallengelab-docker/vagrant]
└─# vagrant up --provider virtualbox virtualbox_vm
Bringing machine 'virtualbox_vm' up with 'virtualbox' provider...
==> virtualbox_vm: Importing base box 'generic/debian12'...
==> virtualbox_vm: Matching MAC address for NAT networking...
==> virtualbox_vm: Checking if box 'generic/debian12' version '4.3.12' is up to date...
==> virtualbox_vm: Setting the name of the VM: WiFiChallenge Lab v2.4.1
==> virtualbox_vm: Clearing any previously set network interfaces...
==> virtualbox_vm: Preparing network interfaces based on configuration...
    virtualbox_vm: Adapter 1: nat
==> virtualbox_vm: Forwarding ports...
    virtualbox_vm: 22 (guest) => 2222 (host) (adapter 1)
==> virtualbox_vm: Running 'pre-boot' VM customizations...
==> virtualbox_vm: Booting VM...
==> virtualbox_vm: Waiting for machine to boot. This may take a few minutes...
    virtualbox_vm: SSH address: 127.0.0.1:2222
    virtualbox_vm: SSH username: vagrant
    virtualbox_vm: SSH auth method: private key
    virtualbox_vm:
    virtualbox_vm: Vagrant insecure key detected. Vagrant will automatically replace
    virtualbox_vm: this with a newly generated keypair for better security.
    virtualbox_vm:
    virtualbox_vm: Inserting generated public key within guest...
    virtualbox_vm: Removing insecure key from the guest if it's present...
    virtualbox_vm: Key inserted! Disconnecting and reconnecting using new SSH key...
==> virtualbox_vm: Machine booted and ready!
==> virtualbox_vm: Setting hostname...
==> virtualbox_vm: Running provisioner: file...
    virtualbox_vm: /usr/share/virtualbox/VBoxGuestAdditions.iso => /tmp/VBoxGuestAdditions.iso
==> virtualbox_vm: Running provisioner: shell...
    virtualbox_vm: Running: inline script
    virtualbox_vm: Get:1 http://deb.debian.org/debian bookworm InRelease [151 kB]
    virtualbox_vm: Get:2 http://security.debian.org/debian-security bookworm-security InRelease [48.0 kB]
[...]
    virtualbox_vm: Setting up grub2-common (2.06-13+deb12u2) ...
    virtualbox_vm: Setting up grub-pc-bin (2.06-13+deb12u2) ...
    virtualbox_vm: Setting up linux-compiler-gcc-12-x86 (6.1.174-1) ...
    virtualbox_vm: Setting up grub-pc (2.06-13+deb12u2) ...
    virtualbox_vm: grub-pc: Running grub-install ...
    virtualbox_vm: /dev/disk/by-id/ata-VBOX_HARDDISK_VBef3f4778-d7168a38 does not exist, so cannot grub-install to it!
    virtualbox_vm: You must correct your GRUB install devices before proceeding:
    virtualbox_vm:
    virtualbox_vm:   DEBIAN_FRONTEND=dialog dpkg --configure grub-pc
    virtualbox_vm:   dpkg --configure -a
    virtualbox_vm: dpkg: error processing package grub-pc (--configure):
    virtualbox_vm:  installed grub-pc package post-installation script subprocess returned error exit status 1
    virtualbox_vm: Setting up bind9-dnsutils (1:9.18.49-1~deb12u1) ...
    virtualbox_vm: Setting up linux-headers-6.1.0-49-amd64 (6.1.174-1) ...
    virtualbox_vm: /etc/kernel/header_postinst.d/dkms:
    virtualbox_vm: dkms: running auto installation service for kernel 6.1.0-49-amd64.
    virtualbox_vm: dkms: autoinstall for kernel: 6.1.0-49-amd64.
    virtualbox_vm: Setting up linux-headers-amd64 (6.1.174-1) ...
    virtualbox_vm: Processing triggers for systemd (252.39-1~deb12u2) ...
    virtualbox_vm: Processing triggers for man-db (2.11.2-2) ...
    virtualbox_vm: Processing triggers for dbus (1.14.10-1~deb12u1) ...
    virtualbox_vm: Processing triggers for debianutils (5.7-0.5~deb12u1) ...
    virtualbox_vm: Processing triggers for mailcap (3.70+nmu1) ...
    virtualbox_vm: Processing triggers for libc-bin (2.36-9+deb12u14) ...
    virtualbox_vm: Processing triggers for initramfs-tools (0.142+deb12u3) ...
    virtualbox_vm: update-initramfs: Generating /boot/initrd.img-6.1.0-49-amd64
    virtualbox_vm: Processing triggers for ca-certificates (20230311+deb12u1) ...
    virtualbox_vm: Updating certificates in /etc/ssl/certs...
    virtualbox_vm: 0 added, 0 removed; done.
    virtualbox_vm: Running hooks in /etc/ca-certificates/update.d...
    virtualbox_vm: done.
    virtualbox_vm: Errors were encountered while processing:
    virtualbox_vm:  grub-pc
    virtualbox_vm: E: Sub-process /usr/bin/dpkg returned an error code (1)
The SSH command responded with a non-zero exit status. Vagrant
assumes that this means the command failed. The output for this command
should be in the log above. Please read the output to determine what
went wrong.

┌──(root㉿kali)-[~/.wifichallengelab-docker/vagrant]
└─#
```
